### PR TITLE
Pack XL3 packets for cross-compiler compatibility.

### DIFF
--- a/src/net/XL3PacketTypes.h
+++ b/src/net/XL3PacketTypes.h
@@ -72,6 +72,8 @@
 #define ERROR_ID 0xFE
 #define SCREWED_ID 0xFF
 
+#pragma pack(1)
+
 typedef struct
 {
   uint16_t packetNum;
@@ -451,6 +453,6 @@ typedef struct{
   uint32_t initialized;
 } CheckXL3StateResults;
 
-
+#pragma pack()
 
 #endif


### PR DESCRIPTION
This should make the packets more robust to compiler differences in struct packing/alignment. As it is, whatever Xcode uses to build objective-c (either llvm or clang) has different packing/alignment rules than whatever builds penn_daq / XL3. This removes all packing for the XL3 packets which is the most compatible method I could come up with.