### PR TITLE
Add TUBii to TTot test to obviate need for cable swaps

### DIFF
--- a/src/mtc/MTCRegisters.h
+++ b/src/mtc/MTCRegisters.h
@@ -140,7 +140,7 @@
 #define MSK_CRATE24 0x00800000UL
 #define MSK_CRATE25 0x01000000UL
 #define MSK_TUB     MSK_CRATE21         // everyone's favorite board!  
-
+#define MSK_TUBII   MSK_CRATE24         // Eric's favorite board!!
 /* Threshold Monitoring */
 
 #define TMON_NHIT100LO  0x00020000UL

--- a/src/tests/TTot.cpp
+++ b/src/tests/TTot.cpp
@@ -20,7 +20,7 @@ int GetTTot(int crateNum, uint32_t slotMask, int targetTime, int updateDB, int f
   try {
 
     // setup the mtc with the triggers going to the TUB
-    int errors = mtc->SetupPedestals(0,60,100,0,(0x1<<crateNum) | MSK_CRATE21,MSK_CRATE21);
+    int errors = mtc->SetupPedestals(0,60,100,0,(0x1<<crateNum) | MSK_CRATE21,MSK_CRATE21 | MSK_TUBII);
 
     int result = MeasureTTot(crateNum,slotMask,150,times);
 
@@ -106,7 +106,7 @@ int SetTTot(int crateNum, uint32_t slotMask, int targetTime, int updateDB, int f
   try {
 
     // setup the mtc with the triggers going to the TUB
-    int errors = mtc->SetupPedestals(0,60,100,0,(0x1<<crateNum) | MSK_CRATE21,MSK_CRATE21);
+    int errors = mtc->SetupPedestals(0,60,100,0,(0x1<<crateNum) | MSK_CRATE21,MSK_CRATE21 | MSK_TUBII);
 
     for (int i=0;i<16;i++){
       if ((0x1<<i) & slotMask){


### PR DESCRIPTION
You might already have a better fix in the works but this will be good enough to allow us to do ecals over the weekend if need be.  If you think though you can get a version in place that actually talks to TUBii before then than that'd be better and you can ignore this